### PR TITLE
the 'ADPCM' and 'Extended Module:' string comparisons should be case sensitive

### DIFF
--- a/src/load_mod.cpp
+++ b/src/load_mod.cpp
@@ -341,7 +341,7 @@ BOOL CSoundFile::ReadMod(const BYTE *lpStream, DWORD dwMemLength)
 		LPSTR p = (LPSTR)(lpStream+dwMemPos);
 		UINT flags = 0;
 		if (dwMemPos + 5 >= dwMemLength) break;
-		if (!strncasecmp(p, "ADPCM", 5))
+		if (! strncmp(p, "ADPCM", 5))
 		{
 			flags = 3;
 			p += 5;

--- a/src/load_xm.cpp
+++ b/src/load_xm.cpp
@@ -89,7 +89,7 @@ BOOL CSoundFile::ReadXM(const BYTE *lpStream, DWORD dwMemLength)
 
 	m_nChannels = 0;
 	if ((!lpStream) || (dwMemLength < 0x200)) return FALSE;
-	if (strncasecmp((LPCSTR)lpStream, "Extended Module", 15)) return FALSE;
+	if (strncmp((LPCSTR)lpStream, "Extended Module:", 16)) return FALSE;
 
 	memcpy(m_szNames[0], lpStream+17, 20);
 	xmhead = *(tagXMFILEHEADER *)(lpStream+60);


### PR DESCRIPTION
As mentioned by sagamusix in issue #10
