### PR TITLE
Add emulation of the FT2 pattern loop bug.

### DIFF
--- a/src/libmodplug/sndfile.h
+++ b/src/libmodplug/sndfile.h
@@ -578,7 +578,7 @@ public:	// for Editing
 	UINT m_nType, m_nSamples, m_nInstruments;
 	UINT m_nTickCount, m_nTotalCount, m_nPatternDelay, m_nFrameDelay;
 	UINT m_nMusicSpeed, m_nMusicTempo;
-	UINT m_nNextRow, m_nRow;
+	UINT m_nNextRow, m_nRow, m_nNextStartRow;
 	UINT m_nPattern,m_nCurrentPattern,m_nNextPattern,m_nRestartPos;
 	UINT m_nMasterVolume, m_nGlobalVolume, m_nSongPreAmp;
 	UINT m_nFreqFactor, m_nTempoFactor, m_nOldGlbVolSlide;

--- a/src/sndfile.cpp
+++ b/src/sndfile.cpp
@@ -103,6 +103,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
 	m_nFrameDelay = 0;
 	m_nNextRow = 0;
 	m_nRow = 0;
+	m_nNextStartRow = 0;
 	m_nPattern = 0;
 	m_nCurrentPattern = 0;
 	m_nNextPattern = 0;
@@ -244,6 +245,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
 	m_nTickCount = m_nMusicSpeed;
 	m_nNextRow = 0;
 	m_nRow = 0;
+	m_nNextStartRow = 0;
 	if ((m_nRestartPos >= MAX_ORDERS) || (Order[m_nRestartPos] >= MAX_PATTERNS)) m_nRestartPos = 0;
 	// Load plugins
 	if (gpMixPluginCreateProc)
@@ -678,6 +680,7 @@ void CSoundFile::SetCurrentPos(UINT nPos)
 	}
 	m_nNextPattern = nPattern;
 	m_nNextRow = nRow;
+	m_nNextStartRow = 0;
 	m_nTickCount = m_nMusicSpeed;
 	m_nBufferCount = 0;
 	m_nPatternDelay = 0;
@@ -706,7 +709,7 @@ void CSoundFile::SetCurrentOrder(UINT nPos)
 	} else
 	{
 		m_nNextPattern = nPos;
-		m_nRow = m_nNextRow = 0;
+		m_nRow = m_nNextRow = m_nNextStartRow = 0;
 		m_nPattern = 0;
 		m_nTickCount = m_nMusicSpeed;
 		m_nBufferCount = 0;

--- a/src/sndmix.cpp
+++ b/src/sndmix.cpp
@@ -419,7 +419,8 @@ BOOL CSoundFile::ProcessRow()
 		if (m_nNextRow >= PatternSize[m_nPattern])
 		{
 			if (!(m_dwSongFlags & SONG_PATTERNLOOP)) m_nNextPattern = m_nCurrentPattern + 1;
-			m_nNextRow = 0;
+			m_nNextRow = m_nNextStartRow;
+			m_nNextStartRow = 0;
 		}
 		// Reset channel values
 		MODCHANNEL *pChn = Chn;


### PR DESCRIPTION
One of the most (in)famous FT2 bugs is the E60 bug: When E60 is used on
a pattern row x, the following pattern also starts from row x instead of
the beginning of the pattern. This can be avoided by placing a D00
pattern break on the last row of the pattern where E60 was used.

Described here: http://www.milkytracker.org/docs/MilkyTracker.html#fxE6x

Test tune:
http://api.modarchive.org/downloads.php?moduleid=55647#roadblas.xm
