### PR TITLE
mmcmp: fix big-endian 16-bit conversion

### DIFF
--- a/src/mmcmp.cpp
+++ b/src/mmcmp.cpp
@@ -275,7 +275,8 @@ BOOL MMCMP_Unpack(LPCBYTE *ppMemFile, LPDWORD pdwMemLength)
 					{
 						newval ^= 0x8000;
 					}
-					pDest[dwPos++] = (WORD)newval;
+					WORD swapped = (WORD)newval;
+					pDest[dwPos++] = bswapLE16(swapped);
 				}
 				if (dwPos >= dwSize)
 				{


### PR DESCRIPTION
mmcmp: fix big-endian 16-bit conversion (store the converted value in little-endian order.)
