### PR TITLE
Fix handling of single-row loops

### DIFF
--- a/src/snd_fx.cpp
+++ b/src/snd_fx.cpp
@@ -2120,7 +2120,11 @@ int CSoundFile::PatternLoop(MODCHANNEL *pChn, UINT param)
 		if (pChn->nPatternLoopCount)
 		{
 			pChn->nPatternLoopCount--;
-			if (!pChn->nPatternLoopCount) return -1;
+			if (!pChn->nPatternLoopCount)
+			{
+				pChn->nPatternLoop = 0;
+				return -1;
+			}
 		} else
 		{
 			MODCHANNEL *p = Chn;
@@ -2130,6 +2134,9 @@ int CSoundFile::PatternLoop(MODCHANNEL *pChn, UINT param)
 				if (p->nPatternLoopCount) return -1;
 			}
 			pChn->nPatternLoopCount = param;
+			// Single row loop, no loop start position
+			if (pChn->nPatternLoop == 0)
+				pChn->nPatternLoop = m_nRow;
 		}
 		return pChn->nPatternLoop;
 	} else


### PR DESCRIPTION
In S3M files, at least, a pattern loop effect (SBn) without a preceding
start marker (SB0) repeats that single row. If a mod file has a single
row loop after a normal loop in the same pattern, this would cause an
infinite loop, since the first loop resets the later loop's counter, but
both loop to the same point.

This fixes the endless loop bug I reported on SourceForge