### PR TITLE
Fix bugs when reading empty files

### DIFF
--- a/src/load_mid.cpp
+++ b/src/load_mid.cpp
@@ -751,6 +751,7 @@ BOOL CSoundFile::TestMID(const BYTE *lpStream, DWORD dwMemLength)
 	mm.mm = (char *)lpStream;
 	mm.sz = dwMemLength;
 	h.mmf = &mm;
+	if (h.mmf->sz < 4) return FALSE;
 	mmfseek(h.mmf,0,SEEK_SET);
 	mmreadSBYTES(id, 4, h.mmf);
 	id[4] = '\0';

--- a/src/load_psm.cpp
+++ b/src/load_psm.cpp
@@ -105,11 +105,12 @@ BOOL CSoundFile::ReadPSM(LPCBYTE lpStream, DWORD dwMemLength)
 	BYTE samplemap[MAX_SAMPLES];
 	UINT nPatterns;
 	
+	if (dwMemLength < 256) return FALSE;
+
 	// Swap chunk
 	swap_PSMCHUNK(pfh);
 	
 	// Chunk0: "PSM ",filesize,"FILE"
-	if (dwMemLength < 256) return FALSE;
 	if (pfh->id == PSM_ID_OLD)
 	{
 	#ifdef PSM_LOG


### PR DESCRIPTION
When reading an empty file at two places invalid memory reads happen. Add appropriate checks to avoid that.

The invalid memory reads can be seen with memory safety tools like address sanitizer or valgrind.