### PR TITLE
Update CMakeLists to detect sinf and stdint.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,17 @@ project(libmodplug)
 add_definitions(-DMODPLUG_BUILD)
 
 include (CheckFunctionExists)
+include (CheckIncludeFile)
 
 include_directories(AFTER
   src
   src/libmodplug
   ${PROJECT_BINARY_DIR}
   )
+
+if (UNIX)
+  set (CMAKE_REQUIRED_LIBRARIES m)
+endif()
 
 if (WIN32)
   add_definitions(-D_USE_MATH_DEFINES)
@@ -43,6 +48,11 @@ if (WIN32 AND NOT (MINGW OR MSYS))
     message(WARNING
       "Compilation may fail if inttypes.h is not natively supported by the compiler."
       "You can get inttypes.h from http://code.google.com/p/msinttypes/")
+  endif()
+else()
+  check_include_file("stdint.h" HAVE_STDINT)
+  if (HAVE_STDINT)
+    add_definitions(-DHAVE_STDINT_H)
   endif()
 endif()
 


### PR DESCRIPTION
Hello! I tried to build this library on my Ubuntu machine using CMake and ran into two issues that this PR fixes.

First off, the "HAVE_STDINT_H" preprocessor flag is only set inside the if (WIN32...) block, so it wasn't set when I tried to build which resulted in a bunch of errors like `libmodplug/src/libmodplug/stdafx.h:70:9: error: ‘uint8_t’ does not name a type; did you mean ‘u_int8_t’?`

Second, the `check_function_exists("sinf", HAVE_SINF)` seems to fail all the time for me, so "HAVE_SINF" is never set. This results in errors like `libmodplug/src/load_pat.cpp:153:21: error: ‘float sinf(float)’ was declared ‘extern’ and later ‘static’ [-fpermissive]`. From some googling it appears the solution is to run `set (CMAKE_REQUIRED_LIBRARIES m)`.

I tried to make the code alter as little of the old behavior as possible so hopefully it shouldn't break anything for other users. Please let me know if there is any change I need to make to get this merged!