### PR TITLE
MSC_VER preprocessor check corrections

### DIFF
--- a/src/fastmix.cpp
+++ b/src/fastmix.cpp
@@ -9,7 +9,7 @@
 #include "sndfile.h"
 #include <math.h>
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 #pragma bss_seg(".modplug")
 #endif
 
@@ -27,7 +27,7 @@ int MixRearBuffer[MIXBUFFERSIZE*2];
 float MixFloatBuffer[MIXBUFFERSIZE*2];
 #endif
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 #pragma bss_seg()
 #endif
 
@@ -1611,7 +1611,7 @@ UINT CSoundFile::CreateStereoMix(int count)
 #endif
 
 // Clip and convert to 8 bit
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 __declspec(naked) DWORD MPPASMCALL X86_Convert32To8(LPVOID lp16, int *pBuffer, DWORD lSampleCount, LPLONG lpMin, LPLONG lpMax)
 //------------------------------------------------------------------------------
 {
@@ -1701,7 +1701,7 @@ DWORD MPPASMCALL X86_Convert32To8(LPVOID lp8, int *pBuffer, DWORD lSampleCount, 
 #endif //MSC_VER, else
 
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 // Clip and convert to 16 bit
 __declspec(naked) DWORD MPPASMCALL X86_Convert32To16(LPVOID lp16, int *pBuffer, DWORD lSampleCount, LPLONG lpMin, LPLONG lpMax)
 //------------------------------------------------------------------------------
@@ -1794,7 +1794,7 @@ DWORD MPPASMCALL X86_Convert32To16(LPVOID lp16, int *pBuffer, DWORD lSampleCount
 }
 #endif //MSC_VER, else
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 // Clip and convert to 24 bit
 __declspec(naked) DWORD MPPASMCALL X86_Convert32To24(LPVOID lp16, int *pBuffer, DWORD lSampleCount, LPLONG lpMin, LPLONG lpMax)
 //------------------------------------------------------------------------------
@@ -1902,7 +1902,7 @@ DWORD MPPASMCALL X86_Convert32To24(LPVOID lp16, int *pBuffer, DWORD lSampleCount
 }
 #endif
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 // Clip and convert to 32 bit
 __declspec(naked) DWORD MPPASMCALL X86_Convert32To32(LPVOID lp16, int *pBuffer, DWORD lSampleCount, LPLONG lpMin, LPLONG lpMax)
 //------------------------------------------------------------------------------
@@ -1992,7 +1992,7 @@ DWORD MPPASMCALL X86_Convert32To32(LPVOID lp16, int *pBuffer, DWORD lSampleCount
 #endif
 
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 void MPPASMCALL X86_InitMixBuffer(int *pBuffer, UINT nSamples)
 //------------------------------------------------------------
 {
@@ -2034,7 +2034,7 @@ void MPPASMCALL X86_InitMixBuffer(int *pBuffer, UINT nSamples)
 #endif
 
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 __declspec(naked) void MPPASMCALL X86_InterleaveFrontRear(int *pFrontBuf, int *pRearBuf, DWORD nSamples)
 //------------------------------------------------------------------------------
 {
@@ -2079,7 +2079,7 @@ void MPPASMCALL X86_InterleaveFrontRear(int *pFrontBuf, int *pRearBuf, DWORD nSa
 #endif
 
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 VOID MPPASMCALL X86_MonoFromStereo(int *pMixBuf, UINT nSamples)
 //-------------------------------------------------------------
 {
@@ -2116,7 +2116,7 @@ VOID MPPASMCALL X86_MonoFromStereo(int *pMixBuf, UINT nSamples)
 #define OFSDECAYMASK	0xFF
 
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 void MPPASMCALL X86_StereoFill(int *pBuffer, UINT nSamples, LPLONG lpROfs, LPLONG lpLOfs)
 //------------------------------------------------------------------------------
 {
@@ -2217,7 +2217,7 @@ void MPPASMCALL X86_StereoFill(int *pBuffer, UINT nSamples, LPLONG lpROfs, LPLON
 }
 #endif
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 void MPPASMCALL X86_EndChannelOfs(MODCHANNEL *pChannel, int *pBuffer, UINT nSamples)
 //------------------------------------------------------------------------------
 {
@@ -2291,7 +2291,7 @@ void MPPASMCALL X86_EndChannelOfs(MODCHANNEL *pChannel, int *pBuffer, UINT nSamp
 #define MIXING_LIMITMAX		(0x08100000)
 #define MIXING_LIMITMIN		(-MIXING_LIMITMAX)
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 __declspec(naked) UINT MPPASMCALL X86_AGC(int *pBuffer, UINT nSamples, UINT nAGC)
 //------------------------------------------------------------------------------
 {
@@ -2327,7 +2327,6 @@ agcupdate:
 	jmp agcrecover
 	}
 }
-
 #pragma warning (default:4100)
 #else
 // Version for GCC
@@ -2378,11 +2377,9 @@ void CSoundFile::ProcessAGC(int count)
 }
 
 
-
 void CSoundFile::ResetAGC()
 //-------------------------
 {
 	gnAGC = AGC_UNITY;
 }
-
 #endif // NO_AGC

--- a/src/libmodplug/sndfile.h
+++ b/src/libmodplug/sndfile.h
@@ -943,7 +943,7 @@ typedef struct WAVEEXTRAHEADER
 #define AGC_UNITY			(1 << AGC_PRECISION)
 
 // Calling conventions
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 #define MPPASMCALL	__cdecl
 #define MPPFASTCALL	__fastcall
 #else

--- a/src/libmodplug/stdafx.h
+++ b/src/libmodplug/stdafx.h
@@ -27,7 +27,7 @@
 
 #ifdef _WIN32
 
-#ifdef MSC_VER
+#ifdef _MSC_VER
 #pragma warning (disable:4201)
 #pragma warning (disable:4514)
 #endif

--- a/src/load_xm.cpp
+++ b/src/load_xm.cpp
@@ -11,7 +11,7 @@
 ////////////////////////////////////////////////////////
 // FastTracker II XM file support
 
-#ifdef MSC_VER
+#ifdef _MSC_VER
 #pragma warning(disable:4244)
 #endif
 

--- a/src/snd_flt.cpp
+++ b/src/snd_flt.cpp
@@ -13,12 +13,11 @@
 
 #ifndef NO_FILTER
 
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 #define _ASM_MATH
 #endif
 
 #ifdef _ASM_MATH
-
 // pow(a,b) returns a^^b -> 2^^(b.log2(a))
 static float pow(float a, float b)
 {
@@ -41,7 +40,6 @@ static float pow(float a, float b)
 	}
 	return result;
 }
-
 
 #else
 

--- a/src/snd_fx.cpp
+++ b/src/snd_fx.cpp
@@ -9,7 +9,7 @@
 #include "sndfile.h"
 #include "tables.h"
 
-#ifdef MSC_VER
+#ifdef _MSC_VER
 #pragma warning(disable:4244)
 #endif
 

--- a/src/sndfile.cpp
+++ b/src/sndfile.cpp
@@ -1654,8 +1654,7 @@ void CSoundFile::AdjustSampleLoop(MODINSTRUMENT *pIns)
 DWORD CSoundFile::TransposeToFrequency(int transp, int ftune)
 //-----------------------------------------------------------
 {
-
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 	const float _fbase = 8363;
 	const float _factor = 1.0f/(12.0f*128.0f);
 	int result;
@@ -1695,8 +1694,7 @@ DWORD CSoundFile::TransposeToFrequency(int transp, int ftune)
 int CSoundFile::FrequencyToTranspose(DWORD freq)
 //----------------------------------------------
 {
-
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 	const float _f1_8363 = 1.0f / 8363.0f;
 	const float _factor = 128 * 12;
 	LONG result;

--- a/src/sndmix.cpp
+++ b/src/sndmix.cpp
@@ -80,7 +80,7 @@ const UINT PreAmpAGCTable[16] =
 // Return (a*b)/c - no divide error
 int _muldiv(long a, long b, long c)
 {
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 	int sign, result;
 	_asm {
 	mov eax, a
@@ -123,11 +123,10 @@ rneg:
 #endif
 }
 
-
 // Return (a*b+c/2)/c - no divide error
 int _muldivr(long a, long b, long c)
 {
-#ifdef MSC_VER
+#if defined(_MSC_VER) && defined(_M_IX86)
 	int sign, result;
 	_asm {
 	mov eax, a
@@ -338,7 +337,6 @@ MixDone:
 	if (nStat) { m_nMixStat += nStat-1; m_nMixStat /= nStat; }
 	return lMax - lRead;
 }
-
 
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
1. correct some _MSC_VER ifdefs
    load_pat.c is excluded: it's handled in PR #41.

2. changed several 'MSC_VER' checks into '_MSC_VER && _M_IX86' checks
    they are supposed to be guarding Visual Studio inline IX86 asm code
