### PR TITLE
new C api functions ModPlug_GetVersion and ModPlug_Tell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(libmodplug)
 
-set(VERSION "0.8.9.1")
+set(VERSION "0.8.10.0")
 
 option(BUILD_SHARED_LIBS "Build Shared Library (DLL)" OFF)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
 
-AC_INIT([libmodplug],[0.8.9.1])
+AC_INIT([libmodplug],[0.8.10.0])
 AC_CONFIG_SRCDIR([Makefile.am])
 
 AM_INIT_AUTOMAKE

--- a/src/modplug.cpp
+++ b/src/modplug.cpp
@@ -81,6 +81,11 @@ namespace ModPlug
 	}
 }
 
+long ModPlug_GetVersion(void)
+{
+	return LIBMODPLUG_VERSION;
+}
+
 ModPlugFile* ModPlug_Load(const void* data, int size)
 {
 	ModPlugFile* result = new ModPlugFile;

--- a/src/modplug.cpp
+++ b/src/modplug.cpp
@@ -270,6 +270,21 @@ void ModPlug_Seek(ModPlugFile* file, int millisecond)
 	file->mSoundFile.SetCurrentPos((int)(millisecond * postime));
 }
 
+int ModPlug_Tell(ModPlugFile *file)
+{
+	int currentPos = (int)file->mSoundFile.GetCurrentPos();
+	int maxpos;
+	int maxtime = (int)file->mSoundFile.GetSongTime() * 1000;
+	float postime;
+	maxpos = (int)file->mSoundFile.GetMaxPosition();
+	postime = 0.0f;
+	if (maxtime != 0.0f)
+	    postime = (float)maxpos / (float)maxtime;
+	if (postime == 0.0f)
+	    return 0;
+	return (int) ((float)currentPos / postime);
+}
+
 void ModPlug_GetSettings(ModPlug_Settings* settings)
 {
 	memcpy(settings, &ModPlug::gSettings, sizeof(ModPlug_Settings));

--- a/src/modplug.h
+++ b/src/modplug.h
@@ -13,8 +13,8 @@ extern "C" {
 
 #define LIBMODPLUG_MAJOR		0L
 #define LIBMODPLUG_MINOR		8L
-#define LIBMODPLUG_REVISION		9L
-#define LIBMODPLUG_PATCH		1L
+#define LIBMODPLUG_REVISION		10L
+#define LIBMODPLUG_PATCH		0L
 #define LIBMODPLUG_VERSION		\
     ((LIBMODPLUG_MAJOR   <<24) |	\
      (LIBMODPLUG_MINOR   <<16) |	\
@@ -78,6 +78,9 @@ MODPLUG_EXPORT int ModPlug_GetLength(ModPlugFile* file);
  * note that seeking is not very exact in some mods -- especially those for which
  * ModPlug_GetLength() does not report the full length. */
 MODPLUG_EXPORT void ModPlug_Seek(ModPlugFile* file, int millisecond);
+
+/* Get the absolute playing position in song, in milliseconds. */
+MODPLUG_EXPORT int ModPlug_Tell(ModPlugFile* file);
 
 enum _ModPlug_Flags
 {

--- a/src/modplug.h
+++ b/src/modplug.h
@@ -11,6 +11,16 @@
 extern "C" {
 #endif
 
+#define LIBMODPLUG_MAJOR		0L
+#define LIBMODPLUG_MINOR		8L
+#define LIBMODPLUG_REVISION		9L
+#define LIBMODPLUG_PATCH		1L
+#define LIBMODPLUG_VERSION		\
+    ((LIBMODPLUG_MAJOR   <<24) |	\
+     (LIBMODPLUG_MINOR   <<16) |	\
+     (LIBMODPLUG_REVISION<< 8) |	\
+     (LIBMODPLUG_PATCH))
+
 #if defined(_WIN32) || defined(__CYGWIN__)
 # if defined(MODPLUG_BUILD) && defined(DLL_EXPORT)	/* building libmodplug as a dll for windows */
 #   define MODPLUG_EXPORT __declspec(dllexport)
@@ -24,6 +34,8 @@ extern "C" {
 #else
 #define MODPLUG_EXPORT
 #endif
+
+MODPLUG_EXPORT long ModPlug_GetVersion(void);
 
 struct _ModPlugFile;
 typedef struct _ModPlugFile ModPlugFile;


### PR DESCRIPTION
1. Add new C api function ModPlug_GetVersion, add version macros to modplug.h
2. Add new C api function ModPlug_Tell to get the playing position in msecs
   The function was originally authored and is provided by Vitaly Novichkov.
   Increase the version number to 0.8.10 so the new functions can be checked
   easily at compile time.
