### PR TITLE
Use GNUInstallDirs for install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ add_definitions(-DMODPLUG_BUILD)
 
 include (CheckFunctionExists)
 include (CheckIncludeFile)
+include (GNUInstallDirs)
 
 include_directories(AFTER
   src
@@ -119,7 +120,7 @@ add_library(modplug ${LIB_TYPE}
   )
 
 # install the library:
-install(TARGETS modplug DESTINATION lib)
+install(TARGETS modplug DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # incstall the headers:
 install(FILES
@@ -129,7 +130,7 @@ install(FILES
   src/modplug.h
 
   DESTINATION
-  include/libmodplug
+  ${CMAKE_INSTALL_INCLUDEDIR}/libmodplug
   )
 
 set(VERSION "0.8.8.5")
@@ -142,14 +143,14 @@ if(HAVE_SINF)
 endif(HAVE_SINF)
 
 if (NOT WIN32)
-  set(prefix "${CMAKE_INSTALL_PREFIX}")
-  set(exec_prefix "${CMAKE_INSTALL_PREFIX}")
-  set(libdir "${CMAKE_INSTALL_PREFIX}/lib")
-  set(includedir "${CMAKE_INSTALL_PREFIX}/include")
+  set(prefix ${CMAKE_INSTALL_PREFIX})
+  set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+  set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+  set(includedir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
   configure_file(libmodplug.pc.in libmodplug.pc)
 
   # install pkg-config file:
   install(FILES "${PROJECT_BINARY_DIR}/libmodplug.pc"
-    DESTINATION lib/pkgconfig
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 endif (NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ add_definitions(-DMODPLUG_BUILD)
 
 include (CheckFunctionExists)
 include (CheckIncludeFile)
-include (GNUInstallDirs)
 
 include_directories(AFTER
   src
@@ -120,14 +119,17 @@ add_library(modplug ${LIB_TYPE}
   )
 
 # install the library:
-install(TARGETS modplug DESTINATION ${CMAKE_INSTALL_LIBDIR})
+include (GNUInstallDirs)
+install(TARGETS modplug
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 
-# incstall the headers:
+# install the headers:
 install(FILES
-  src/libmodplug/it_defs.h
-  src/libmodplug/sndfile.h
-  src/libmodplug/stdafx.h
   src/modplug.h
+  ${HEADERS_CXX}
 
   DESTINATION
   ${CMAKE_INSTALL_INCLUDEDIR}/libmodplug
@@ -151,6 +153,6 @@ if (NOT WIN32)
 
   # install pkg-config file:
   install(FILES "${PROJECT_BINARY_DIR}/libmodplug.pc"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 endif (NOT WIN32)


### PR DESCRIPTION
This causes the install paths to be consistent on whatever platform/architecture it's running on.

[More info on GNUInstallDirs is here](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html)