### PR TITLE
Fix broken bitshifts in GCC version of X86_Convert32To24

### DIFF
--- a/src/fastmix.cpp
+++ b/src/fastmix.cpp
@@ -1887,13 +1887,13 @@ DWORD MPPASMCALL X86_Convert32To24(LPVOID lp16, int *pBuffer, DWORD lSampleCount
 			vumax = n;
 		p = n >> (8-MIXING_ATTENUATION) ; // 24-bit signed
 #ifdef WORDS_BIGENDIAN
-		buf[i*3+0] = p & 0xFF0000 >> 24;
-		buf[i*3+1] = p & 0x00FF00 >> 16 ;
-		buf[i*3+2] = p & 0x0000FF ;
+		buf[i*3+0] = (p >> 16) & 0xFF;
+		buf[i*3+1] = (p >> 8)  & 0xFF;
+		buf[i*3+2] = (p >> 0)  & 0xFF;
 #else
-		buf[i*3+0] = p & 0x0000FF ;
-		buf[i*3+1] = p & 0x00FF00 >> 16;
-		buf[i*3+2] = p & 0xFF0000 >> 24;
+		buf[i*3+0] = (p >> 0)  & 0xFF;
+		buf[i*3+1] = (p >> 8)  & 0xFF;
+		buf[i*3+2] = (p >> 16) & 0xFF;
 #endif
 	}
 	*lpMin = vumin;


### PR DESCRIPTION
This patch is based on a patch by @adelva1984 that has been [sitting around in the MegaZeux repository](https://github.com/AliceLR/megazeux/blob/master/contrib/patches/libmodplug/02-libmodplug-0.8.9.0-fix-X86_Convert32To24.diff) for a while. The original bitshifts are obviously wrong and result in 2 of the 3 sample bytes being 0 or 0xFF instead of the intended value.