### PR TITLE
Fix volume event handling for .FAR modules.

### DIFF
--- a/src/load_far.cpp
+++ b/src/load_far.cpp
@@ -151,11 +151,10 @@ BOOL CSoundFile::ReadFAR(const BYTE *lpStream, DWORD dwMemLength)
 				m->instr = ins + 1;
 				m->note = note + 36;
 			}
-			if (vol & 0x0F)
+			if (vol >= 0x01 && vol <= 0x10)
 			{
 				m->volcmd = VOLCMD_VOLUME;
-				m->vol = (vol & 0x0F) << 2;
-				if (m->vol <= 4) m->vol = 0;
+				m->vol = (vol - 1) << 2;
 			}
 			switch(eff & 0xF0)
 			{


### PR DESCRIPTION
Volume event handling for .FAR modules is slightly wrong, which mainly results in notes that are supposed to play with maximum volume not playing at all in some tracks. Despite what the [documentation](https://modland.com/pub/documents/format_documentation/Farandole%20Composer%20(.far).txt) says, volume in .FAR modules is encoded as:

* `0x00` → no change
* `0x01` → volume=0
* `0x02` → volume=1
...
* `0x10` → volume=15

I dumped raw pattern data from some modules with this issue to show that this is consistent between .FAR modules. The third byte in each column is the volume byte. `0x00` bytes are shown as blank space. I trimmed out some data that wasn't required to make the point.

[rainruin.far.zip](https://github.com/Konstanty/libmodplug/files/5399717/rainruin.far.zip)
![rainruin2](https://user-images.githubusercontent.com/1750531/96411683-1b962480-11a6-11eb-8731-e697b15241df.png)
```
: pattern 16: length=2050, expected_rows=32, break byte=30, difference=2
: 05 01 0a b8:          b8:          b8:          b8:          b8:          b8:       0f   :       0f   :       0f   :       0f   :       01   :          b8:
:            :            :            :            :            :            :       0e   :       0e   :       0e   :       0e   :            :            :
:            : 0c 01 0a   :            :            :            :            :       0d   :       0d   :       0d   :       0d   :            :            :
:            :            :            :            :            :            :       0c   :       0c   :       0c   :       0c   :            :            :
:            :            : 11 01 0a   :            :            :            :       0b   :       0b   :       0b   :       0b   :            :            :
:            :            :            :            :            :            :       0a   :       0a   :       0a   :       0a   :            :            :
:            :            :            : 18 01 0a   :            :            :       09   :       09   :       09   :       09   :            :            :
:            :            :            :            :            :            :       08   :       08   :       08   :       08   :            :       0f   :
: 03 01 0a   :            :            :            :            :            :       07   :       07   :       07   :       07   :            :       0e   :
:            :            :            :            :            :            :       06   :       06   :       06   :       06   :            :       0d   :
:            : 0d 01 0a   :            :            :            :            :       05   :       05   :       05   :       05   :            :       0c   :
:            :            :            :            :            :            :       04   :       04   :       04   :       04   :            :       0b   :
:            :            : 18 01 0a   :            :            :            :       03   :       03   :       03   :       03   :            :       0a   :
:            :            :            :            :            :            :       02   :       02   :       02   :       02   :            :       09   :
:            :            :            : 1d 01 0a   :            :            :       01   :       01   :       01   :       01   :            :       08   :
:            :            :            :            :            :            :            :            :            :            :            :       07   :
: 01 01 0a   :            : 0d 01 0a   :            :            :            :            :            :            :            :            :       06   :
:            :            :            :            :            :            :            :            :            :            :            :       05   :
:            : 22 01 0a   :            :            :            :            :            :            :            :            :            :       04   :
:            :            :            :            :            :            :            :            :            :            :            :       03   :
:            :            : 24 01 0a   :            :            :            :            :            :            :            :            :       02   :
:            :            :            :            :            :            :            :            :            :            :            :       01   :
```

[m31.far.zip](https://github.com/Konstanty/libmodplug/files/5399720/m31.far.zip)
[m31.png](https://user-images.githubusercontent.com/1750531/96411729-2f418b00-11a6-11eb-92be-e0609f01497c.png)
[m31.txt](https://github.com/Konstanty/libmodplug/files/5399722/m31.txt)

[residual ambient amperage.far.zip](https://github.com/Konstanty/libmodplug/files/5399724/residual.ambient.amperage.far.zip)
[residual.png](https://user-images.githubusercontent.com/1750531/96411756-38caf300-11a6-11eb-80bf-ef8a8570dd2f.png)
[residual.txt](https://github.com/Konstanty/libmodplug/files/5399729/residual.txt)