### PR TITLE
Add check for CD61 magic to MOD loader.

### DIFF
--- a/src/load_mod.cpp
+++ b/src/load_mod.cpp
@@ -208,6 +208,7 @@ BOOL CSoundFile::ReadMod(const BYTE *lpStream, DWORD dwMemLength)
 	if ((IsMagic(s, "M.K.")) || (IsMagic(s, "M!K!"))
 	 || (IsMagic(s, "M&K!")) || (IsMagic(s, "N.T."))) m_nChannels = 4; else
 	if ((IsMagic(s, "CD81")) || (IsMagic(s, "OKTA"))) m_nChannels = 8; else
+	if (IsMagic(s, "CD61")) m_nChannels = 6; else
 	if ((s[0]=='F') && (s[1]=='L') && (s[2]=='T') && (s[3]>='4') && (s[3]<='9')) m_nChannels = s[3] - '0'; else
 	if ((s[0]>='2') && (s[0]<='9') && (s[1]=='C') && (s[2]=='H') && (s[3]=='N')) m_nChannels = s[0] - '0'; else
 	if ((s[0]=='1') && (s[1]>='0') && (s[1]<='9') && (s[2]=='C') && (s[3]=='H')) m_nChannels = s[1] - '0' + 10; else


### PR DESCRIPTION
This is an Octalyser (Atari) MOD magic for 6 channel modules. There aren't very many of these but it's trivial to check for and the (current) alternative is that libmodplug tries to load it as a garbled ST 15-instrument MOD.

Example file: [new age.mod.zip](https://github.com/Konstanty/libmodplug/files/5611789/new.age.mod.zip)