### PR TITLE
Fix tempo for 669 modules.

### DIFF
--- a/src/load_669.cpp
+++ b/src/load_669.cpp
@@ -71,7 +71,7 @@ BOOL CSoundFile::Read669(const BYTE *lpStream, DWORD dwMemLength)
 	m_dwSongFlags |= SONG_LINEARSLIDES;
 	m_nMinPeriod = 28 << 2;
 	m_nMaxPeriod = 1712 << 3;
-	m_nDefaultTempo = 125;
+	m_nDefaultTempo = 78;
 	m_nDefaultSpeed = 6;
 	m_nChannels = 8;
 	memcpy(m_szNames[0], pfh->songmessage, 16);
@@ -154,7 +154,7 @@ BOOL CSoundFile::Read669(const BYTE *lpStream, DWORD dwMemLength)
 					case 0x02:	command = CMD_TONEPORTAMENTO; break;
 					case 0x03:	command = CMD_MODCMDEX; param |= 0x50; break;
 					case 0x04:	command = CMD_VIBRATO; param |= 0x40; break;
-					case 0x05:	if (param) command = CMD_SPEED; else command = 0; param += 2; break;
+					case 0x05:	if (param) command = CMD_SPEED; else command = 0; break;
 					case 0x06:	if (param == 0) { command = CMD_PANNINGSLIDE; param = 0xFE; }
 								else if (param == 1) { command = CMD_PANNINGSLIDE; param = 0xEF; }
 								else command = 0;
@@ -174,7 +174,7 @@ BOOL CSoundFile::Read669(const BYTE *lpStream, DWORD dwMemLength)
 				for (UINT i=0; i<8; i++) if (!mspeed[i].command)
 				{
 					mspeed[i].command = CMD_SPEED;
-					mspeed[i].param = pfh->tempolist[npat] + 2;
+					mspeed[i].param = pfh->tempolist[npat];
 					break;
 				}
 			}


### PR DESCRIPTION
The 669 loader was using 125 as the default BPM for 669 modules and adding 2 to 669 tempos when converting them to speeds. Since 669 tempos are fairly analogous to MOD speeds this predictably causes some playback speed issues (see attached module). The fix is just to get rid of the `speed = tempo + 2` hacks and lower the BPM.

I don't know exactly how to derive the new BPM value (78) but several other player libraries I tested use it. I verified with COMPOSD1 that it is fairly accurate at various different speeds (the actual equivalent MOD BPM I measured is about 77.5).

Example file:
[crystals.669.zip](https://github.com/Konstanty/libmodplug/files/5611891/crystals.669.zip)