### PR TITLE
CMake: Fix install paths on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,10 @@ add_library(modplug ${LIB_TYPE}
   )
 
 # install the library:
-install(TARGETS modplug DESTINATION lib)
+install(TARGETS modplug
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)
 
 # incstall the headers:
 install(FILES


### PR DESCRIPTION
By only setting `DESTINATION` for the install directory of target `modplug`, a DLL file on Windows, which traditionally goes in the `bin` folder, erroneously gets placed into the `lib` folder. By setting `RUNTIME`, `LIBRARY`, and `ARCHIVE`, DLL files are placed correctly in `bin` for Win32, and other library/linking files are placed correctly into `lib`.

The CMake documentation recommends writing this way here: https://cmake.org/cmake/help/latest/command/install.html#installing-targets