### PR TITLE
Fix IT note fades, compressed stereo samples, approximate command \xx

### DIFF
--- a/src/load_it.cpp
+++ b/src/load_it.cpp
@@ -433,16 +433,16 @@ BOOL CSoundFile::ReadIT(const BYTE *lpStream, DWORD dwMemLength)
 				if (pis.flags & 2)
 				{
 					flags += 5;
-					if (pis.flags & 4) flags |= RSF_STEREO;
 					pins->uFlags |= CHN_16BIT;
 					// IT 2.14 16-bit packed sample ?
 					if (pis.flags & 8) flags = ((pifh.cmwt >= 0x215) && (pis.cvt & 4)) ? RS_IT21516 : RS_IT21416;
+					if (pis.flags & 4) flags |= RSF_STEREO;
 				} else
 				{
-					if (pis.flags & 4) flags |= RSF_STEREO;
 					if (pis.cvt == 0xFF) flags = RS_ADPCM4; else
 					// IT 2.14 8-bit packed sample ?
 					if (pis.flags & 8)	flags =	((pifh.cmwt >= 0x215) && (pis.cvt & 4)) ? RS_IT2158 : RS_IT2148;
+					if (pis.flags & 4) flags |= RSF_STEREO;
 				}
 				ReadSample(&Ins[nsmp+1], flags, (LPSTR)(lpStream+pis.samplepointer), dwMemLength - pis.samplepointer);
 			}
@@ -1213,11 +1213,12 @@ DWORD ITReadBits(DWORD &bitbuf, UINT &bitnum, LPBYTE &ibuf, CHAR n)
 }
 
 #define IT215_SUPPORT
-void ITUnpack8Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, BOOL b215)
-//-------------------------------------------------------------------------------------------
+DWORD ITUnpack8Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, DWORD channels, BOOL b215)
+//-------------------------------------------------------------------------------------------------------------------
 {
 	signed char *pDst = pSample;
 	LPBYTE pSrc = lpMemFile;
+	DWORD writePos = 0;
 	DWORD wHdr = 0;
 	DWORD wCount = 0;
 	DWORD bitbuf = 0;
@@ -1278,28 +1279,30 @@ void ITUnpack8Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwM
 			bTemp = (BYTE)wBits;
 			bTemp2 += bTemp;
 #ifdef IT215_SUPPORT
-			pDst[dwPos] = (b215) ? bTemp2 : bTemp;
+			pDst[writePos] = (b215) ? bTemp2 : bTemp;
 #else
-			pDst[dwPos] = bTemp;
+			pDst[writePos] = bTemp;
 #endif
 		SkipByte:
 			dwPos++;
+			writePos += channels;
 		Next:
-			if (pSrc >= lpMemFile+dwMemLength+1) return;
+			if (pSrc >= lpMemFile+dwMemLength+1) return (DWORD)(pSrc - lpMemFile);
 		} while (dwPos < d);
 		// Move On
 		wCount -= d;
 		dwLen -= d;
-		pDst += d;
 	}
+	return (DWORD)(pSrc - lpMemFile);
 }
 
 
-void ITUnpack16Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, BOOL b215)
-//--------------------------------------------------------------------------------------------
+DWORD ITUnpack16Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, DWORD channels, BOOL b215)
+//--------------------------------------------------------------------------------------------------------------------
 {
 	signed short *pDst = (signed short *)pSample;
 	LPBYTE pSrc = lpMemFile;
+	DWORD writePos = 0;
 	DWORD wHdr = 0;
 	DWORD wCount = 0;
 	DWORD bitbuf = 0;
@@ -1361,21 +1364,22 @@ void ITUnpack16Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dw
 			wTemp = (signed short)dwBits;
 			wTemp2 += wTemp;
 #ifdef IT215_SUPPORT
-			pDst[dwPos] = (b215) ? wTemp2 : wTemp;
+			pDst[writePos] = (b215) ? wTemp2 : wTemp;
 #else
-			pDst[dwPos] = wTemp;
+			pDst[writePos] = wTemp;
 #endif
 		SkipByte:
 			dwPos++;
+			writePos += channels;
 		Next:
-			if (pSrc >= lpMemFile+dwMemLength+1) return;
+			if (pSrc >= lpMemFile+dwMemLength+1) return (DWORD)(pSrc - lpMemFile);
 		} while (dwPos < d);
 		// Move On
 		wCount -= d;
 		dwLen -= d;
-		pDst += d;
 		if (pSrc >= lpMemFile+dwMemLength) break;
 	}
+	return (DWORD)(pSrc - lpMemFile);
 }
 
 

--- a/src/load_s3m.cpp
+++ b/src/load_s3m.cpp
@@ -98,6 +98,7 @@ void CSoundFile::S3MConvert(MODCOMMAND *m, BOOL bIT) const
 	case 'X':	command = CMD_PANNING8; break;
 	case 'Y':	command = CMD_PANBRELLO; break;
 	case 'Z':	command = CMD_MIDI; break;
+	case '\\':  command = CMD_MIDI; break;
 	default:	command = 0;
 	}
 	m->command = command;

--- a/src/snd_fx.cpp
+++ b/src/snd_fx.cpp
@@ -430,7 +430,14 @@ void CSoundFile::NoteChange(UINT nChn, int note, BOOL bPorta, BOOL bResetEnv)
 	if (note >= 0x80)	// 0xFE or invalid note => key off
 	{
 		// Key Off
-		KeyOff(nChn);
+		if (note < 0xFD && m_nType == MOD_TYPE_IT)
+		{
+			if (m_nInstruments)
+				pChn->dwFlags |= CHN_NOTEFADE;
+		} else
+		{
+			KeyOff(nChn);
+		}
 		// Note Cut
 		if (note == 0xFE)
 		{

--- a/src/sndfile.cpp
+++ b/src/sndfile.cpp
@@ -19,9 +19,8 @@ extern BOOL MMCMP_Unpack(LPCBYTE *ppMemFile, LPDWORD pdwMemLength);
 extern void AMSUnpack(const char *psrc, UINT inputlen, char *pdest, UINT dmax, char packcharacter);
 extern WORD MDLReadBits(DWORD &bitbuf, UINT &bitnum, LPBYTE &ibuf, CHAR n);
 extern int DMFUnpack(LPBYTE psample, LPBYTE ibuf, LPBYTE ibufmax, UINT maxlen);
-extern DWORD ITReadBits(DWORD &bitbuf, UINT &bitnum, LPBYTE &ibuf, CHAR n);
-extern void ITUnpack8Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, BOOL b215);
-extern void ITUnpack16Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, BOOL b215);
+extern DWORD ITUnpack8Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, DWORD channels, BOOL b215);
+extern DWORD ITUnpack16Bit(signed char *pSample, DWORD dwLen, LPBYTE lpMemFile, DWORD dwMemLength, DWORD channels, BOOL b215);
 
 
 #define MAX_PACK_TABLES		3
@@ -1310,9 +1309,26 @@ UINT CSoundFile::ReadSample(MODINSTRUMENT *pIns, UINT nFlags, LPCSTR lpMemFile, 
 		len = dwMemLength;
 		if (len < 4) break;
 		if ((nFlags == RS_IT2148) || (nFlags == RS_IT2158))
-			ITUnpack8Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, (nFlags == RS_IT2158));
+			ITUnpack8Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, 1, (nFlags == RS_IT2158));
 		else
-			ITUnpack16Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, (nFlags == RS_IT21516));
+			ITUnpack16Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, 1, (nFlags == RS_IT21516));
+		break;
+
+	case RS_IT2148 | RSF_STEREO:
+	case RS_IT21416 | RSF_STEREO:
+	case RS_IT2158 | RSF_STEREO:
+	case RS_IT21516 | RSF_STEREO:
+		len = dwMemLength;
+		if (len < 4) break;
+		if ((nFlags == (RS_IT2148 | RSF_STEREO)) || (nFlags == (RS_IT2158 | RSF_STEREO)))
+		{
+			DWORD offset = ITUnpack8Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, 2, (nFlags == (RS_IT2158 | RSF_STEREO)));
+			ITUnpack8Bit(pIns->pSample + 1, pIns->nLength, (LPBYTE)lpMemFile + offset, dwMemLength - offset, 2, (nFlags == (RS_IT2158 | RSF_STEREO)));
+		} else
+		{
+			DWORD offset = ITUnpack16Bit(pIns->pSample, pIns->nLength, (LPBYTE)lpMemFile, dwMemLength, 2, (nFlags == (RS_IT21516 | RSF_STEREO)));
+			ITUnpack16Bit(pIns->pSample + 2, pIns->nLength, (LPBYTE)lpMemFile + offset, dwMemLength - offset, 2, (nFlags == (RS_IT21516 | RSF_STEREO)));
+		}
 		break;
 
 #ifndef MODPLUG_BASIC_SUPPORT


### PR DESCRIPTION
If people keep using the library, might as well fix the most blatantly missing IT features to make modern IT tracks lightly more listenable: Compressed stereo samples and note fades. As a bonus, OpenMPT command \xx (Smooth MIDI Macro) is now imported as command Zxx (MIDI macro).