### PR TITLE
configure.ac: revert the hardcoded -macosx-version-min switches.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,13 +46,6 @@ case "$host" in
 esac
 AC_SUBST(LT_LDFLAGS)
 
-# require 10.5+ for osx/x86_64 builds
-case "$host" in
-	x86_64-*-darwin*)
-		CXXFLAGS="$CXXFLAGS -mmacosx-version-min=10.5"
-		LDFLAGS="$LDFLAGS -mmacosx-version-min=10.5" ;;
-esac
-
 # symbol visibility
 ac_save_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$CXXFLAGS -fvisibility=hidden -Werror"


### PR DESCRIPTION
was added by commit 28f938cfa5df213e740, and it was a **bad** idea..