### PR TITLE
Fix more issues from the fuzz-patch-1/oob_read_fixes merge.

### DIFF
--- a/src/load_mdl.cpp
+++ b/src/load_mdl.cpp
@@ -303,15 +303,14 @@ BOOL CSoundFile::ReadMDL(const BYTE *lpStream, DWORD dwMemLength)
 					if ((Headers[nins] = new INSTRUMENTHEADER) == NULL) break;
 					INSTRUMENTHEADER *penv = Headers[nins];
 					memset(penv, 0, sizeof(INSTRUMENTHEADER));
-					if (dwPos < dwMemLength - 34)
-						memcpy(penv->name, lpStream+dwPos+2, 32);
+					if (dwPos > dwMemLength - 34) break;
+					memcpy(penv->name, lpStream+dwPos+2, 32);
 					penv->nGlobalVol = 64;
 					penv->nPPC = 5*12;
 					if (34 + 14u*lpStream[dwPos+1] > dwMemLength - dwPos) break;
 					for (j=0; j<lpStream[dwPos+1]; j++)
 					{
 						const BYTE *ps = lpStream+dwPos+34+14*j;
-						if (dwPos+34+14*j >= dwMemLength - 12) break;
 						while ((note < (UINT)(ps[1]+12)) && (note < NOTE_MAX))
 						{
 							penv->NoteMap[note] = note+1;

--- a/src/load_mt2.cpp
+++ b/src/load_mt2.cpp
@@ -288,7 +288,7 @@ BOOL CSoundFile::ReadMT2(LPCBYTE lpStream, DWORD dwMemLength)
 		const MT2PATTERN *pmp = (MT2PATTERN *)(lpStream+dwMemPos);
 		UINT wDataLen = (pmp->wDataLen + 1) & ~1;
 		dwMemPos += 6;
-		if (dwMemLength - wDataLen > dwMemLength || dwMemPos + wDataLen > dwMemLength) break;
+		if (dwMemPos > dwMemLength - wDataLen || wDataLen > dwMemLength) break;
 
 		UINT nLines = pmp->wLines;
 		if ((iPat < MAX_PATTERNS) && (nLines > 0) && (nLines <= 256))
@@ -560,7 +560,7 @@ BOOL CSoundFile::ReadMT2(LPCBYTE lpStream, DWORD dwMemLength)
 	m_nSamples = (pfh->wSamples < MAX_SAMPLES) ? pfh->wSamples : MAX_SAMPLES-1;
 	for (UINT iSmp=1; iSmp<=256; iSmp++)
 	{
-		if (dwMemPos+36 > dwMemLength || dwMemPos > dwMemLength) return TRUE;
+		if (dwMemPos > dwMemLength - 36) return TRUE;
 		const MT2SAMPLE *pms = (MT2SAMPLE *)(lpStream+dwMemPos);
 	#ifdef MT2DEBUG
 		if (iSmp <= m_nSamples) Log("  Sample #%d at offset %04X: %d bytes\n", iSmp, dwMemPos, pms->dwDataLen);


### PR DESCRIPTION
More stuff that needed attention from #66 and #67, from the loaders I didn't check for that patch. I had to turn off UBSan for testing these loaders because it seems that the MT2 loader (and maybe others) also has alignment issues like Oktalyzer did.

There will be a third patch for the MIDI loader, after which I *think* all of the merge conflicts between those two branches should be resolved. I split it off of this patch because there are no clean options for fixing it.

* MDL: tweaked oob_read_fixes check at 305 to break from loop.
* MDL: oob_read_fixes check at 313 and fuzz-patch-1 check at 309 are redundant. Removed 313 since 309 is outside of the loop.
* MT2: the oob_read_fixes check at line 291 was kind of broken. Replaced with the fuzz-patch-1 variant of that check.
* MT2: combine the two checks on line 563.