### PR TITLE
fixes to Libs.private in .pc file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,15 @@ install(FILES
   ${CMAKE_INSTALL_INCLUDEDIR}/libmodplug
 )
 
-if (NOT WIN32)
+if (NOT MSVC)
+  if(MINGW OR CYGWIN)
+    set(LIBS_PRIVATE "-luser32 -lstdc++")
+  else()
+    set(LIBS_PRIVATE "-lstdc++")
+    if(MATH_LIB)
+      set(LIBS_PRIVATE "${LIBS_PRIVATE} -lm")
+    endif()
+  endif()
   set(prefix ${CMAKE_INSTALL_PREFIX})
   set(exec_prefix ${CMAKE_INSTALL_PREFIX})
   set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
@@ -168,4 +176,4 @@ if (NOT WIN32)
   install(FILES "${PROJECT_BINARY_DIR}/libmodplug.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
-endif (NOT WIN32)
+endif ()

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ CXXFLAGS="$CXXFLAGS -fno-exceptions -Wall -ffast-math -fno-common -D_REENTRANT"
 
 AC_CANONICAL_HOST
 
+LIBS_PRIVATE=-lstdc++
 LIBM=
 case "${host_os}" in
 dnl Djgpp has all c89 math funcs in libc.a
@@ -35,14 +36,17 @@ darwin*|haiku*|beos*|cegcc*|pw32*)
   ;;
 dnl MinGW and Cygwin don't need libm, either
 mingw*|cygwin*)
+  LIBS_PRIVATE="-luser32 ${LIBS_PRIVATE}"
   ;;
 dnl All others:
 *) AC_CHECK_LIB(m, pow, LIBM="-lm")
   if test x$LIBM != x; then
     LIBS="${LIBS} ${LIBM}"
+    LIBS_PRIVATE="${LIBS_PRIVATE} ${LIBM}"
   fi
   ;;
 esac
+AC_SUBST(LIBS_PRIVATE)
 AC_CHECK_FUNCS(sinf)
 
 # symbol visibility

--- a/libmodplug.pc.in
+++ b/libmodplug.pc.in
@@ -7,6 +7,6 @@ Name: libmodplug
 Description: The ModPlug mod file playing library.
 Version: @VERSION@
 Requires: 
-Libs: -L${libdir} -lmodplug 
-Libs.private: -lstdc++ -lm
+Libs: -L${libdir} -lmodplug
+Libs.private: @LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Closes: https://github.com/Konstanty/libmodplug/pull/59

A minor concern is that `-lstdc++` _may_ be the wrong library, i.e. think
of clang. However, this does not make things worse: such a case should be
handled in a different patch.