### PR TITLE
reduce / fix platform-dependent code usage:

### DIFF
--- a/src/libmodplug/stdafx.h
+++ b/src/libmodplug/stdafx.h
@@ -34,8 +34,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <windowsx.h>
-#include <mmsystem.h>
+#include <mmsystem.h> /* for WAVE_FORMAT_PCM */
 #include <stdio.h>
 #include <malloc.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
@@ -49,9 +48,7 @@ typedef unsigned int   uint32_t;
 #include <stdint.h>
 #endif
 
-#define srandom(_seed)  srand(_seed)
-#define random()        rand()
-#define sleep(_ms)      Sleep(_ms)
+#define sleep(_ms)      Sleep(_ms * 1000)
 
 inline void ProcessPlugins(int n) { (void)n; }
 
@@ -91,7 +88,7 @@ typedef uint32_t* LPDWORD;
 typedef uint16_t WORD;
 typedef uint8_t BYTE;
 typedef uint8_t* LPBYTE;
-typedef bool BOOL;
+typedef bool BOOL; /* FIXME: must be 'int' */
 typedef char* LPSTR;
 typedef void* LPVOID;
 typedef uint16_t* LPWORD;
@@ -106,16 +103,6 @@ typedef void VOID;
 #define wsprintf sprintf
 
 #define WAVE_FORMAT_PCM 1
-
-#define  GHND   0
-#define GlobalFreePtr(p) free((void *)(p))
-inline int8_t * GlobalAllocPtr(unsigned int, size_t size)
-{
-  int8_t * p = (int8_t *) malloc(size);
-
-  if (p != NULL) memset(p, 0, size);
-  return p;
-}
 
 inline void ProcessPlugins(int n) { (void)n; }
 

--- a/src/load_669.cpp
+++ b/src/load_669.cpp
@@ -17,7 +17,7 @@
 typedef struct tagFILEHEADER669
 {
 	WORD sig;				// 'if' or 'JN'
-        signed char songmessage[108];	// Song Message
+	char songmessage[108];			// Song Message
 	BYTE samples;			// number of samples (1-64)
 	BYTE patterns;			// number of patterns (1-128)
 	BYTE restartpos;

--- a/src/load_abc.cpp
+++ b/src/load_abc.cpp
@@ -31,8 +31,8 @@
 #include <math.h>
 #include <ctype.h>
 #ifndef _WIN32
-#include <unistd.h> // for sleep
-#endif // _WIN32
+#include <unistd.h>  /* sleep() */
+#endif
 
 #include "stdafx.h"
 #include "sndfile.h"
@@ -2373,8 +2373,8 @@ static ABCHANDLE *ABC_Init(void)
 		}
 	}
 	else {
-		srandom((uint32_t)time(0));	// initialize random generator with seed
-		retval->pickrandom = 1+(int)(10000.0*random()/(RAND_MAX+1.0));
+		srand((unsigned int)time(0));	// initialize random generator with seed
+		retval->pickrandom = 1+(int)(10000.0*rand()/(RAND_MAX+1.0));
 		// can handle pickin' from songbooks with 10.000 songs
 		sprintf(buf,"%s=-%ld",ABC_ENV_NORANDOMPICK,retval->pickrandom); // xmms preloads the file
 		putenv(buf);

--- a/src/load_mid.cpp
+++ b/src/load_mid.cpp
@@ -30,7 +30,7 @@
 #include <math.h>
 #include <ctype.h>
 #ifndef _WIN32
-#include <unistd.h> // for sleep
+#include <unistd.h> /* sleep() */
 #endif
 
 #include "stdafx.h"

--- a/src/load_pat.cpp
+++ b/src/load_pat.cpp
@@ -33,9 +33,9 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
-#include <limits.h> // for PATH_MAX
+#include <limits.h> /* PATH_MAX */
 #ifndef _WIN32
-#include <unistd.h> // for sleep
+#include <unistd.h>  /* sleep() */
 #endif
 
 #include "stdafx.h"

--- a/src/mmcmp.cpp
+++ b/src/mmcmp.cpp
@@ -184,7 +184,7 @@ BOOL MMCMP_Unpack(LPCBYTE *ppMemFile, LPDWORD pdwMemLength)
 		return FALSE;
 	}
 	dwFileSize = pmmh->filesize;
-	if ((pBuffer = (LPBYTE)GlobalAllocPtr(GHND, (dwFileSize + 31) & ~15)) == NULL)
+	if ((pBuffer = (LPBYTE)calloc(1, (dwFileSize + 31) & ~15)) == NULL)
 		return FALSE;
 	pBufEnd = pBuffer + dwFileSize;
 	pblk_table = (const DWORD *)(lpMemFile+pmmh->blktable);
@@ -538,7 +538,7 @@ BOOL PP20_Unpack(LPCBYTE *ppMemFile, LPDWORD pdwMemLength)
 	//Log("PP20 detected: Packed length=%d, Unpacked length=%d\n", dwMemLength, dwDstLen);
 	if ((dwDstLen < 512) || (dwDstLen > 0x400000) || (dwDstLen > 16*dwMemLength))
 		return FALSE;
-	if ((pBuffer = (LPBYTE)GlobalAllocPtr(GHND, (dwDstLen + 31) & ~15)) == NULL)
+	if ((pBuffer = (LPBYTE)calloc(1, (dwDstLen + 31) & ~15)) == NULL)
 		return FALSE;
 
 	if (!ppDecrunch(lpMemFile+8, pBuffer, tmp, dwMemLength-12, dwDstLen, skip)) {

--- a/src/sndfile.cpp
+++ b/src/sndfile.cpp
@@ -167,7 +167,7 @@ BOOL CSoundFile::Create(LPCBYTE lpStream, DWORD dwMemLength)
 #ifdef MMCMP_SUPPORT
 		if (bMMCmp)
 		{
-			GlobalFreePtr(lpStream);
+			free((void*)lpStream);
 			lpStream = NULL;
 		}
 #endif
@@ -354,7 +354,7 @@ void CSoundFile::FreePattern(LPVOID pat)
 signed char* CSoundFile::AllocateSample(UINT nbytes)
 //-------------------------------------------
 {
-	signed char * p = (signed char *)GlobalAllocPtr(GHND, (nbytes+39) & ~7);
+	signed char * p = (signed char *)calloc(1, (nbytes+39) & ~7);
 	if (p) p += 16;
 	return p;
 }
@@ -363,9 +363,8 @@ signed char* CSoundFile::AllocateSample(UINT nbytes)
 void CSoundFile::FreeSample(LPVOID p)
 //-----------------------------------
 {
-	if (p)
-	{
-		GlobalFreePtr(((LPSTR)p)-16);
+	if (p) {
+		free((char*)p - 16);
 	}
 }
 


### PR DESCRIPTION
- replace GlobalAllocPtr/GlobalFreePtr with calloc/free. (this
  also fixes bad use of free() in mmcmp.cpp which was added by
  PR #77 by mistake.)
- replace POSIX.1 sranrom/random with ANSI C srand/rand.
- fix wrong translation of POSIX.1 sleep() into Windows Sleep()
- remove now-unnecessary windowsx.h include
- add FIXME note about the BOOL typedef: it really must be 'int'
  but no changing it...
