### PR TITLE
load_pat.cpp: fix several issues with processing of timidity.cfg

### DIFF
--- a/src/load_pat.cpp
+++ b/src/load_pat.cpp
@@ -387,10 +387,10 @@ void pat_init_patnames(void)
 			isdrumset = 0;
 			_mm_fgets(mmcfg, line, PATH_MAX);
 			while( !_mm_feof(mmcfg) ) {
-			if( isdigit(line[0]) || (isblank(line[0]) && isdigit(line[1])) ) {
-				p = line;
+			p = line;
+			while ( isspace(*p) ) p ++;
+			if( isdigit(p[0]) ) {
 				// get pat number
-				while ( isspace(*p) ) p ++;
 				i = atoi(p);
 				while ( isdigit(*p) ) p ++;
 				while ( isspace(*p) ) p ++;
@@ -418,10 +418,25 @@ void pat_init_patnames(void)
 					*q++ = '\0';
 				}
 			}
-			if( !strncmp(line,"drumset",7) ) isdrumset = 1;
-			if( !strncmp(line,"source",6) && nsources < 5 ) {
+			else if( !strncmp(p,"bank",4) ) isdrumset = 0;
+			else if( !strncmp(p,"drumset",7) ) isdrumset = 1;
+			else if( !strncmp(p,"soundfont",9) ) {
+				fprintf(stderr, "warning: soundfont directive unsupported!\n");
+			}
+			else if( !strncmp(p,"dir",3) )  {
+				p += 3;
+				while ( isspace(*p) ) p ++;
+				q = p + strlen(p);
+				if(q > p) {
+					--q;
+					while ( q > p && isspace(*q) ) *(q--) = 0;
+					strncpy(pathforpat, p, PATH_MAX - 1);
+					pathforpat[PATH_MAX - 1] = 0;
+				}
+			}
+			else if( !strncmp(p,"source",6) && nsources < 5 ) {
 				q = cfgsources[nsources];
-				p = &line[7];
+				p += 6;
 				while ( isspace(*p) ) p ++;
 				pfnlen = 0;
 				while ( *p && *p != '#' && !isspace(*p) && pfnlen < 128 ) {
@@ -459,9 +474,9 @@ void pat_init_patnames(void)
 
 static char *pat_build_path(char *fname, int pat)
 {
-	char *ps;
+	char *ps, *p;
 	char *patfile = midipat[pat];
-	int isabspath = (patfile[0] == '/');
+	int has_ext = 0, isabspath = (patfile[0] == '/');
 	if ( isabspath ) patfile ++;
 	ps = strrchr(patfile, ':');
 	if( ps ) {
@@ -469,7 +484,9 @@ static char *pat_build_path(char *fname, int pat)
 		strcpy(strrchr(fname, ':'), ".pat");
 		return ps;
 	}
-	sprintf(fname, "%s%c%s.pat", isabspath ? "" : pathforpat, DIRDELIM, patfile);
+	p = strrchr(patfile, '.');
+	if(p && !strcasecmp(p, ".pat")) has_ext = 1;
+	sprintf(fname, "%s%c%s%s", isabspath ? "" : pathforpat, DIRDELIM, patfile, has_ext ? "" : ".pat");
 	return 0;
 }
 


### PR DESCRIPTION
- skips leading whitespace
- detect bank directive
- warn on soundfont directive
- implement support for dir directive
- only appends .pat extension if isn't already there

The patch was originally authored by @rofl0r back in the day for
https://github.com/icculus/SDL_sound/issues/16.