### PR TITLE
Add CI via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 
-name: CMake
+name: Builds
 
 jobs:
   cmake-build:
@@ -19,3 +19,23 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{ matrix.build_type }}
+
+  autotools-build:
+    name: Autotools ${{ matrix.os }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        build_type: ["install", "install-strip"]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Autoreconf
+      run: |
+        autoreconf --install "${{github.workspace}}"
+    - name: Make
+      run: |
+        ./configure --prefix=${{github.workspace}}/build 
+        make
+        make ${{ matrix.build_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         build_type: ["Debug", "Release"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-latest"]
         build_type: ["install", "install-strip"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Autoreconf
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+
+name: CMake
+
+jobs:
+  cmake-build:
+    name: CMake ${{ matrix.os }} ${{ matrix.build_type }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        build_type: ["Debug", "Release"]
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{ matrix.build_type }}


### PR DESCRIPTION
This adds some basic CI builds via GitHub Actions.

## CMake

This produces a build matrix `[Linux, Windows, MacOS]` x `[Debug, Release]` and builds libmodplug with CMake with the default detected compiler in the respective GitHub Actions environment (currently: GCC 9, Visual Studio 2019 and Apple Clang 13).

## Autotools

This produces a build matrix `[Linux]` x `[Debug, Release]` and build libmodplug with Autotools with the default detected compiler in the Ubuntu GitHub Actions environment (currently: GCC 9)

___

An exemplary run can be seen here: https://github.com/Croydon/libmodplug/actions/runs/1772652809

Later on, this could be extended to cover more compilers, compiler versions and build systems, but it is a start to get some CI going.

If this is merged, GitHub will run this CI for every future push and pull request, no further configuration is required whatsoever.