### PR TITLE
check presence of strings.h, and include where necessary if available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,14 @@ if (WIN32)
   add_definitions(-DNOMINMAX)
 endif()
 
-check_include_file("stdint.h" HAVE_STDINT)
-if (HAVE_STDINT)
+check_include_file("stdint.h" HAVE_STDINT_H)
+if (HAVE_STDINT_H)
   add_definitions(-DHAVE_STDINT_H)
+endif()
+
+check_include_file("strings.h" HAVE_STRINGS_H)
+if (HAVE_STRINGS_H)
+  add_definitions(-DHAVE_STRINGS_H)
 endif()
 
 check_function_exists("sinf" HAVE_SINF)

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_C_BIGENDIAN
 
 LT_INIT([win32-dll disable-static])
 
-AC_CHECK_HEADERS([inttypes.h stdint.h malloc.h])
+AC_CHECK_HEADERS([inttypes.h stdint.h malloc.h strings.h])
 
 CXXFLAGS="$CXXFLAGS -fno-exceptions -Wall -ffast-math -fno-common -D_REENTRANT"
 

--- a/src/load_abc.cpp
+++ b/src/load_abc.cpp
@@ -28,6 +28,9 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
+#ifdef HAVE_STRINGS_H
+#include <strings.h>
+#endif
 #include <math.h>
 #include <ctype.h>
 #ifndef _WIN32

--- a/src/load_pat.cpp
+++ b/src/load_pat.cpp
@@ -31,6 +31,9 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
+#ifdef HAVE_STRINGS_H
+#include <strings.h>
+#endif
 #include <math.h>
 #include <ctype.h>
 #include <limits.h> // for PATH_MAX


### PR DESCRIPTION
because string.h itself might not prototype strcasecmp.