### PR TITLE
*.AMS Velvet Studio pattern decoding

### DIFF
--- a/src/load_ams.cpp
+++ b/src/load_ams.cpp
@@ -514,6 +514,12 @@ BOOL CSoundFile::ReadAMS2(LPCBYTE lpStream, DWORD dwMemLength)
 				MODCOMMAND *m = Patterns[ipat] + row * m_nChannels;
 				UINT byte1 = psrc[pos++];
 				UINT ch = byte1 & 0x1F;
+				if (byte1 == 0xff)
+				{
+					row++;
+					continue;
+				}
+
 				// Read Note + Instr
 				if (!(byte1 & 0x40))
 				{

--- a/src/load_ams.cpp
+++ b/src/load_ams.cpp
@@ -152,6 +152,13 @@ BOOL CSoundFile::ReadAMS(LPCBYTE lpStream, DWORD dwMemLength)
 		while ((row < PatternSize[iPat]) && (i+2 < len))
 		{
 			BYTE b0 = p[i++];
+
+			if (b0 == 0xff)
+			{
+				row++;
+				continue;
+			}
+
 			BYTE b1 = p[i++];
 			BYTE b2 = 0;
 			UINT ch = b0 & 0x3F;

--- a/src/load_ams.cpp
+++ b/src/load_ams.cpp
@@ -520,6 +520,7 @@ BOOL CSoundFile::ReadAMS2(LPCBYTE lpStream, DWORD dwMemLength)
 			{
 				MODCOMMAND *m = Patterns[ipat] + row * m_nChannels;
 				UINT byte1 = psrc[pos++];
+				UINT byte2;
 				UINT ch = byte1 & 0x1F;
 				if (byte1 == 0xff)
 				{
@@ -530,36 +531,38 @@ BOOL CSoundFile::ReadAMS2(LPCBYTE lpStream, DWORD dwMemLength)
 				// Read Note + Instr
 				if (!(byte1 & 0x40))
 				{
-					UINT byte2 = psrc[pos++];
+					byte2 = psrc[pos++];
 					UINT note = byte2 & 0x7F;
 					if (note) m[ch].note = (note > 1) ? (note-1) : 0xFF;
 					m[ch].instr = psrc[pos++];
-					// Read Effect
-					while (byte2 & 0x80)
+				} else {
+					byte2 = 0x80; /* row contains atleast one effect, so trigged the first parse */
+				}
+				// Read Effect
+				while (byte2 & 0x80)
+				{
+					byte2 = psrc[pos++];
+					if (byte2 & 0x40)
 					{
-						byte2 = psrc[pos++];
-						if (byte2 & 0x40)
+						m[ch].volcmd = VOLCMD_VOLUME;
+						m[ch].vol = byte2 & 0x3F;
+					} else
+					{
+						UINT command = byte2 & 0x3F;
+						UINT param = psrc[pos++];
+						if (command == 0x0C)
 						{
 							m[ch].volcmd = VOLCMD_VOLUME;
-							m[ch].vol = byte2 & 0x3F;
+							m[ch].vol = param / 2;
+						} else
+						if (command < 0x10)
+						{
+							m[ch].command = command;
+							m[ch].param = param;
+							ConvertModCommand(&m[ch]);
 						} else
 						{
-							UINT command = byte2 & 0x3F;
-							UINT param = psrc[pos++];
-							if (command == 0x0C)
-							{
-								m[ch].volcmd = VOLCMD_VOLUME;
-								m[ch].vol = param / 2;
-							} else
-							if (command < 0x10)
-							{
-								m[ch].command = command;
-								m[ch].param = param;
-								ConvertModCommand(&m[ch]);
-							} else
-							{
-								// TODO: AMS effects
-							}
+							// TODO: AMS effects
 						}
 					}
 				}


### PR DESCRIPTION
Comparing the algorithm with the one in Open Cubic Player and with Velvet Studio https://github.com/Patosc/VelvetStudio/blob/master/Code/AMS_LOAD.ASM line 402 a minor detail seems to be missing

First byte in a row with value 0xff is special - meaning that the row is empty.

This is not documented the format documentation of Velvet Studio. Please test this against real Velvet Studio module files (can be found on https://modland.com/pub/modules/Velvet%20Studio/ )