### PR TITLE
Avoid using LPCTSTR

### DIFF
--- a/src/libmodplug/sndfile.h
+++ b/src/libmodplug/sndfile.h
@@ -614,7 +614,7 @@ public:
 	UINT GetMaxPosition() const;
 	void SetCurrentPos(UINT nPos);
 	void SetCurrentOrder(UINT nOrder);
-	void GetTitle(LPSTR s) const { lstrcpyn(s,m_szNames[0],32); }
+	void GetTitle(LPSTR s) const { lstrcpynA(s,m_szNames[0],32); }
 	LPCSTR GetTitle() const { return m_szNames[0]; }
 	UINT GetSampleName(UINT nSample,LPSTR s=NULL) const;
 	UINT GetInstrumentName(UINT nInstr,LPSTR s=NULL) const;

--- a/src/libmodplug/sndfile.h
+++ b/src/libmodplug/sndfile.h
@@ -17,7 +17,8 @@
 int _strnicmp(const char *str1,const char *str2, int n);
 #endif
 
-#ifndef LPCBYTE
+#ifndef _LPCBYTE_DEFINED
+#define _LPCBYTE_DEFINED
 typedef const BYTE * LPCBYTE;
 #endif
 

--- a/src/libmodplug/stdafx.h
+++ b/src/libmodplug/stdafx.h
@@ -96,10 +96,8 @@ typedef const char* LPCSTR;
 typedef void* PVOID;
 typedef void VOID;
 
-#define LPCTSTR LPCSTR
 #define lstrcpyn strncpy
 #define lstrcpy strcpy
-#define lstrcmp strcmp
 #define wsprintf sprintf
 
 #define WAVE_FORMAT_PCM 1

--- a/src/libmodplug/stdafx.h
+++ b/src/libmodplug/stdafx.h
@@ -96,9 +96,9 @@ typedef const char* LPCSTR;
 typedef void* PVOID;
 typedef void VOID;
 
-#define lstrcpyn strncpy
-#define lstrcpy strcpy
-#define wsprintf sprintf
+#define lstrcpynA strncpy
+#define lstrcpyA strcpy
+#define wsprintfA sprintf
 
 #define WAVE_FORMAT_PCM 1
 

--- a/src/load_amf.cpp
+++ b/src/load_amf.cpp
@@ -171,7 +171,7 @@ BOOL CSoundFile::ReadAMF(LPCBYTE lpStream, const DWORD dwMemLength)
 	DWORD dwMemPos;
 
 	if ((!lpStream) || (dwMemLength < 2048)) return FALSE;
-	if ((!strncmp((LPCTSTR)lpStream, "ASYLUM Music Format V1.0", 25)) && (dwMemLength > 4096))
+	if ((!strncmp((LPCSTR)lpStream, "ASYLUM Music Format V1.0", 25)) && (dwMemLength > 4096))
 	{
 		UINT numorders, numpats, numsamples;
 

--- a/src/load_med.cpp
+++ b/src/load_med.cpp
@@ -737,7 +737,7 @@ BOOL CSoundFile::ReadMed(const BYTE *lpStream, DWORD dwMemLength)
 				if (maxnamelen > 32) maxnamelen = 32;
 				for (UINT i=0; i<ientries; i++) if (i < m_nSamples)
 				{
-					lstrcpyn(m_szNames[i+1], psznames + i*ientrysz, maxnamelen);
+					lstrcpynA(m_szNames[i+1], psznames + i*ientrysz, maxnamelen);
 					m_szNames[i+1][31] = '\0';
 				}
 			}
@@ -768,7 +768,7 @@ BOOL CSoundFile::ReadMed(const BYTE *lpStream, DWORD dwMemLength)
 					if (trknamelen > MAX_CHANNELNAME) trknamelen = MAX_CHANNELNAME;
 					if ((trknameofs) && (trknamelen < dwMemLength) && (trknameofs < dwMemLength - trknamelen))
 					{
-						lstrcpyn(ChnSettings[i].szName, (LPCSTR)(lpStream+trknameofs), trknamelen);
+						lstrcpynA(ChnSettings[i].szName, (LPCSTR)(lpStream+trknameofs), trknamelen);
 						ChnSettings[i].szName[MAX_CHANNELNAME-1] = '\0';
 					}
 				}

--- a/src/load_psm.cpp
+++ b/src/load_psm.cpp
@@ -202,7 +202,7 @@ BOOL CSoundFile::ReadPSM(LPCBYTE lpStream, DWORD dwMemLength)
 				CHAR s[8], s2[64];
 				*(DWORD *)s = pchunk.id;
 				s[4] = 0;
-				wsprintf(s2, "%s: %4d bytes @ %4d\n", s, pchunk.len, dwMemPos);
+				wsprintfA(s2, "%s: %4d bytes @ %4d\n", s, pchunk.len, dwMemPos);
 				OutputDebugString(s2);
 			}
 	#endif

--- a/src/load_ptm.cpp
+++ b/src/load_ptm.cpp
@@ -109,7 +109,7 @@ BOOL CSoundFile::ReadPTM(const BYTE *lpStream, DWORD dwMemLength)
 		MODINSTRUMENT *pins = &Ins[ismp+1];
 		PTMSAMPLE *psmp = (PTMSAMPLE *)(lpStream+dwMemPos);
 
-		lstrcpyn(m_szNames[ismp+1], psmp->samplename, 28);
+		lstrcpynA(m_szNames[ismp+1], psmp->samplename, 28);
 		memcpy(pins->name, psmp->filename, 12);
 		pins->name[12] = 0;
 		pins->nGlobalVol = 64;

--- a/src/sndfile.cpp
+++ b/src/sndfile.cpp
@@ -376,13 +376,13 @@ void CSoundFile::ResetMidiCfg()
 //-----------------------------
 {
 	memset(&m_MidiCfg, 0, sizeof(m_MidiCfg));
-	lstrcpy(&m_MidiCfg.szMidiGlb[MIDIOUT_START*32], "FF");
-	lstrcpy(&m_MidiCfg.szMidiGlb[MIDIOUT_STOP*32], "FC");
-	lstrcpy(&m_MidiCfg.szMidiGlb[MIDIOUT_NOTEON*32], "9c n v");
-	lstrcpy(&m_MidiCfg.szMidiGlb[MIDIOUT_NOTEOFF*32], "9c n 0");
-	lstrcpy(&m_MidiCfg.szMidiGlb[MIDIOUT_PROGRAM*32], "Cc p");
-	lstrcpy(&m_MidiCfg.szMidiSFXExt[0], "F0F000z");
-	for (int iz=0; iz<16; iz++) wsprintf(&m_MidiCfg.szMidiZXXExt[iz*32], "F0F001%02X", iz*8);
+	lstrcpyA(&m_MidiCfg.szMidiGlb[MIDIOUT_START*32], "FF");
+	lstrcpyA(&m_MidiCfg.szMidiGlb[MIDIOUT_STOP*32], "FC");
+	lstrcpyA(&m_MidiCfg.szMidiGlb[MIDIOUT_NOTEON*32], "9c n v");
+	lstrcpyA(&m_MidiCfg.szMidiGlb[MIDIOUT_NOTEOFF*32], "9c n 0");
+	lstrcpyA(&m_MidiCfg.szMidiGlb[MIDIOUT_PROGRAM*32], "Cc p");
+	lstrcpyA(&m_MidiCfg.szMidiSFXExt[0], "F0F000z");
+	for (int iz=0; iz<16; iz++) wsprintfA(&m_MidiCfg.szMidiZXXExt[iz*32], "F0F001%02X", iz*8);
 }
 
 
@@ -1789,7 +1789,7 @@ BOOL CSoundFile::SetPatternName(UINT nPat, LPCSTR lpszName)
 	if (nPat >= MAX_PATTERNS) return FALSE;
 	if (lpszName == NULL) return(FALSE);
 
-	if (lpszName) lstrcpyn(szName, lpszName, MAX_PATTERNNAME);
+	if (lpszName) lstrcpynA(szName, lpszName, MAX_PATTERNNAME);
 	szName[MAX_PATTERNNAME-1] = 0;
 	if (!m_lpszPatternNames) m_nPatternNames = 0;
 	if (nPat >= m_nPatternNames)


### PR DESCRIPTION
LPTCSTR isn't defined as const char* in windows if UNICODE is defined.
Also properly guard LPCBYTE.