### PR TITLE
load_abc.cpp (ReadABC): fix -Waddress warning from gcc14

### DIFF
--- a/src/load_abc.cpp
+++ b/src/load_abc.cpp
@@ -3945,7 +3945,7 @@ BOOL CSoundFile::ReadABC(const uint8_t *lpStream, DWORD dwMemLength)
 					char *pm = p;
 					if (mmstack[mmsp]->pos < (LONG)dwMemLength) {
 						pm = abc_continuated(h, mmstack[mmsp], p);
-						if (pm+2)
+						if(*(pm+2))
 							abc_new_macro(h, pm+2);
 					}
 					if( pm != p ) {


### PR DESCRIPTION
```
load_abc.cpp: In member function 'BOOL CSoundFile::ReadABC(const uint8_t*, DWORD)':
load_abc.cpp:3958:55: warning: comparing the result of pointer addition '(pm + 2)' and NULL [-Waddress]
 3958 |                                                 if (pm+2)
      |                                                     ~~^~
```
